### PR TITLE
Log location and memory reservation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miniwdl-lsf"
-version = "0.1.0"
+version = "0.1.1"
 description = "miniwdl lsf backend using singularity"
 authors = ["Andrew Thrasher <adthrasher@gmail.com>"]
 license = "MIT"

--- a/src/miniwdl_lsf/__init__.py
+++ b/src/miniwdl_lsf/__init__.py
@@ -88,15 +88,16 @@ class LSFSingularity(SingularityContainer):
         ]
 
         # Redirect LSF logs to files
-        bsub_args.extend(["-o", os.path.join(self.host_dir, "stdout.lsf")])
-        bsub_args.extend(["-e", os.path.join(self.host_dir, "stderr.lsf")])
+        bsub_args.extend(["-o", os.path.join(self.host_work_dir, "stdout.lsf")])
+        bsub_args.extend(["-e", os.path.join(self.host_work_dir, "stderr.lsf")])
 
         cpu = self.runtime_values.get("cpu", None)
         if cpu is not None:
             bsub_args.extend(["-n", str(cpu)])
             bsub_args.extend(["-R span[hosts=1]"])
 
-        memory = self.runtime_values.get("memory_reservation", None)
+        # Get memory reservation for job in bytes
+        memory = self.runtime_values.get("memory_reservation", 0)
         if memory is not None:
             # LSF memory specifications are per-core.
             # WDL (bioinformatics) tasks often specify memory per job.
@@ -107,7 +108,7 @@ class LSFSingularity(SingularityContainer):
                memory_divisor = cpu
             
             # Round to the nearest megabyte.
-            bsub_args.extend(["-M", f"{round((memory / (1024 ** 2)) / memory_divisor)}M"])
+            bsub_args.extend(["-M", f"{round((memory / (1000 ** 2)) / memory_divisor)}M"])
 
         if self.cfg.has_section("lsf"):
             extra_args = self.cfg.get("lsf", "extra_args")

--- a/src/miniwdl_lsf/__init__.py
+++ b/src/miniwdl_lsf/__init__.py
@@ -88,8 +88,8 @@ class LSFSingularity(SingularityContainer):
         ]
 
         # Redirect LSF logs to files
-        bsub_args.extend(["-o", os.path.join(self.host_work_dir, "stdout.lsf")])
-        bsub_args.extend(["-e", os.path.join(self.host_work_dir, "stderr.lsf")])
+        bsub_args.extend(["-o", os.path.join(self.host_dir, f"stdout{self.try_counter if self.try_counter > 1 else ''}.lsf")])
+        bsub_args.extend(["-e", os.path.join(self.host_dir, f"stderr{self.try_counter if self.try_counter > 1 else ''}.lsf")])
 
         cpu = self.runtime_values.get("cpu", None)
         if cpu is not None:


### PR DESCRIPTION
Place LSF log files in the work directory corresponding to the given run. This avoids appending to a common file for a given step in the case of a rerun. Corrected the memory calculation from bytes to megabytes.