### PR TITLE
Introduce new configuration flag `memory_via_R_flag` to solve #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ example can be used to use miniwdl on a LSF cluster:
     extra_args=""
     # Task memory specifications should be interpreted as per-job not per-core (LSF default)
     memory_per_job = true
+    # Job memory requirement should be specified using -R "rusage[mem=]" instead of -M
+    memory_via_R_flag = false
 ```

--- a/src/miniwdl_lsf/__init__.py
+++ b/src/miniwdl_lsf/__init__.py
@@ -107,8 +107,15 @@ class LSFSingularity(SingularityContainer):
             if self.cfg["lsf"].get_bool("memory_per_job") and cpu is not None:
                memory_divisor = cpu
             
+            # With LSF, memory requests can be specified using the -M or the
+            # -R "rusage[mem=]" flags. By default memory requests will be
+            # specified using the -M flag.
+            # With this option the -R "rusage[mem=]" flag is used instead.
             # Round to the nearest megabyte.
-            bsub_args.extend(["-M", f"{round((memory / (1000 ** 2)) / memory_divisor)}M"])
+            if self.cfg["lsf"].get_bool("memory_via_R_flag"):
+                bsub_args.extend(["-R", f"rusage[mem={round((memory / (1000 ** 2)) / memory_divisor)}M]"])
+            else:
+                bsub_args.extend(["-M", f"{round((memory / (1000 ** 2)) / memory_divisor)}M"])
 
         if self.cfg.has_section("lsf"):
             extra_args = self.cfg.get("lsf", "extra_args")


### PR DESCRIPTION
### Problem: ###
This addresses issue #4

### Solution: ###
The flag allows to switch between specifying memory requirements using the -M flag and the -R "rusage[mem=]" flag when submitting the jobs via bsub. The README.md file is extended accordingly.

### Testing: ###
Job submission was successfully triggered with `memory_via_R_flag = true` on our cluster which requires this setting. Setting `memory_via_R_flag = false` reproduces the error mentione in #4.

### Potential Extentions: ###
1. It is currently required to set the flag to either true or false. The code could be extended to fall back to `-M` when `memory_via_R_flag` is not set.
2. It is currently not possible to include both `-M` and `-R "rusage[mem=]"`. One could think of changing it from a boolean to a character specifying one flag or the other or both.