### PR TITLE
fix: -M -> -R, support memory_limit_multiplier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.1.2
+----------------------------
++ Update memory reservation to use "-R rusage[mem=...]" instead of "-M".
+  To use "-M", set "memory_limit_multiplier" in configuration to a 
+  positive value.
++ Support config option "memory_limit_multiplier" to set a hard limit
+  on memory usage.
+
+version 0.1.1
+----------------------------
++ Update log location on retry
++ Correct memory calculation
+
 version 0.1.0
 ----------------------------
 Initial release with the following features:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ example can be used to use miniwdl on a LSF cluster:
 
     command_shell = /bin/bash
 
-    memory_limit_multiplier=1
+    memory_limit_multiplier = 1.0
  
     [singularity]
     # This plugin wraps the singularity backend. Make sure the settings are

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ example can be used to use miniwdl on a LSF cluster:
         }
 
     command_shell = /bin/bash
+
+    memory_limit_multiplier=1
  
     [singularity]
     # This plugin wraps the singularity backend. Make sure the settings are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miniwdl-lsf"
-version = "0.1.1"
+version = "0.1.2"
 description = "miniwdl lsf backend using singularity"
 authors = ["Andrew Thrasher <adthrasher@gmail.com>"]
 license = "MIT"

--- a/src/miniwdl_lsf/__init__.py
+++ b/src/miniwdl_lsf/__init__.py
@@ -107,6 +107,7 @@ class LSFSingularity(SingularityContainer):
             if self.cfg["lsf"].get_bool("memory_per_job") and cpu is not None:
                memory_divisor = cpu
 
+            # Round to the nearest megabyte and divide by the memory divisor.
             memory_request = round((memory / (1000 ** 2)) / memory_divisor)
             
             # Handle memory limit multiplier.
@@ -115,7 +116,7 @@ class LSFSingularity(SingularityContainer):
                 memory_limit = round(memory_request * memory_limit_multiplier)
                 bsub_args.extend(["-M", f"{memory_limit}M"])
 
-            # Round to the nearest megabyte.
+            # Set memory request.
             bsub_args.extend(["-R", f"rusage[mem={memory_request}M]"])
 
         if self.cfg.has_section("lsf"):

--- a/src/miniwdl_lsf/__init__.py
+++ b/src/miniwdl_lsf/__init__.py
@@ -106,9 +106,17 @@ class LSFSingularity(SingularityContainer):
             memory_divisor = 1
             if self.cfg["lsf"].get_bool("memory_per_job") and cpu is not None:
                memory_divisor = cpu
+
+            memory_request = round((memory / (1000 ** 2)) / memory_divisor)
             
+            # Handle memory limit multiplier.
+            memory_limit_multiplier = self.cfg["task_runtime"].get_float("memory_limit_multiplier")
+            if memory_limit_multiplier > 0.0:
+                memory_limit = round(memory_request * memory_limit_multiplier)
+                bsub_args.extend(["-M", f"{memory_limit}M"])
+
             # Round to the nearest megabyte.
-            bsub_args.extend(["-M", f"{round((memory / (1000 ** 2)) / memory_divisor)}M"])
+            bsub_args.extend(["-R", f"rusage[mem={memory_request}M]"])
 
         if self.cfg.has_section("lsf"):
             extra_args = self.cfg.get("lsf", "extra_args")


### PR DESCRIPTION
Change memory submission from `-M` to `-R`. Add support for configuration option `memory_limit_multiplier` to set a memory limit. `memory_limit_multiplier = 1` will reproduce the prior behavior. Addresses #4.